### PR TITLE
Add operator for dynamic update of sound waveforms

### DIFF
--- a/Interface/Harp.SoundCard/Harp.SoundCard.csproj
+++ b/Interface/Harp.SoundCard/Harp.SoundCard.csproj
@@ -17,6 +17,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageOutputPath>..\bin\$(Configuration)</PackageOutputPath>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <VersionPrefix>0.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>9.0</LangVersion>
@@ -24,6 +25,8 @@
 
   <ItemGroup>
     <PackageReference Include="Bonsai.Harp" Version="3.5.0" />
+    <PackageReference Include="LibUsbDotNet" Version="2.2.29" />
+    <PackageReference Include="OpenCV.Net" Version="3.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Interface/Harp.SoundCard/Properties/launchSettings.json
+++ b/Interface/Harp.SoundCard/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Goncalo Lopes\\Bonsai@InstallDir)Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Bonsai Foundation\\Bonsai@InstallDir)Bonsai.exe",
+      "commandLineArgs": "--lib:$(TargetDir).",
+      "nativeDebugging": true
     }
   }
 }

--- a/Interface/Harp.SoundCard/SampleRate.cs
+++ b/Interface/Harp.SoundCard/SampleRate.cs
@@ -1,0 +1,18 @@
+﻿namespace Harp.SoundCard
+{
+    /// <summary>
+    /// Specifies the available sound sampling rates.
+    /// </summary>
+    public enum SampleRate : int
+    {
+        /// <summary>
+        /// Specifies a sampling rate of 96 kHz.
+        /// </summary>
+        SampleRate96000Hz = 96000,
+
+        /// <summary>
+        /// Specifies a sampling rate of 192 kHz.
+        /// </summary>
+        SampleRate192000Hz = 192000
+    }
+}

--- a/Interface/Harp.SoundCard/SampleType.cs
+++ b/Interface/Harp.SoundCard/SampleType.cs
@@ -1,18 +1,8 @@
 ﻿namespace Harp.SoundCard
 {
-    /// <summary>
-    /// Specifies the available bit depths for sound waveform samples.
-    /// </summary>
     internal enum SampleType : int
     {
-        /// <summary>
-        /// Specifies signed 32-bit samples.
-        /// </summary>
         Int32 = 0,
-
-        /// <summary>
-        /// Specifies single-precision 32-bit floating-point samples.
-        /// </summary>
         Float32 = 1
     }
 }

--- a/Interface/Harp.SoundCard/SampleType.cs
+++ b/Interface/Harp.SoundCard/SampleType.cs
@@ -1,0 +1,18 @@
+﻿namespace Harp.SoundCard
+{
+    /// <summary>
+    /// Specifies the available bit depths for sound waveform samples.
+    /// </summary>
+    public enum SampleType : int
+    {
+        /// <summary>
+        /// Specifies signed 32-bit samples.
+        /// </summary>
+        Int32 = 0,
+
+        /// <summary>
+        /// Specifies single-precision 32-bit floating-point samples.
+        /// </summary>
+        Float32 = 1
+    }
+}

--- a/Interface/Harp.SoundCard/SampleType.cs
+++ b/Interface/Harp.SoundCard/SampleType.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Specifies the available bit depths for sound waveform samples.
     /// </summary>
-    public enum SampleType : int
+    internal enum SampleType : int
     {
         /// <summary>
         /// Specifies signed 32-bit samples.

--- a/Interface/Harp.SoundCard/SoundCardErrorCode.cs
+++ b/Interface/Harp.SoundCard/SoundCardErrorCode.cs
@@ -1,0 +1,99 @@
+﻿namespace Harp.SoundCard
+{
+    internal enum SoundCardErrorCode : int
+    {
+        Ok = 0,
+
+        BadUserInput = -1,
+
+        HarpSoundCardNotDetected = -1000,
+        NotAbleToSendMetadata,
+        NotAbleToReadMetadataCommandReply,
+        MetadataCommandReplyNotCorrect,
+        NotAbleToSendData,
+        NotAbleToReadDataCommandReply,
+        DataCommandReplyNotCorrect,
+        NotAbleToSendReadMetadata,
+        NotAbleToReadReadMetadataCommandRepply,
+        ReadMetadataCommandReplyNotCorrect,
+
+        BadSoundIndex = -1020,
+        BadSoundLength,
+        BadSampleRate,
+        BadDataType,
+        DataTypeDoNotMatch,
+        BadDataIndex,
+
+        ProducingSound = -1030,
+        StartedProducingSound,
+
+        NotAbleToOpenFile = -1040
+    }
+
+    internal static class SoundCardErrorHelper
+    {
+        public static void ThrowExceptionForErrorCode(SoundCardErrorCode code)
+        {
+            switch (code)
+            {
+                case SoundCardErrorCode.Ok:
+                default: return;
+
+                case SoundCardErrorCode.BadUserInput:
+                    throw new SoundCardException(
+                        "User input not correct. The format should be \"filename\" [index] [type] [sample rate] \n" +
+                        " -> [index] from 0 to 31\n" +
+                        " -> [type] 0: Int32, 1: Float32\n" +
+                        " -> [sample rate] 96000 or 192000");
+
+                case SoundCardErrorCode.HarpSoundCardNotDetected:
+                    throw new SoundCardException("Sound card not detected. Is any connected to computer?");
+
+                case SoundCardErrorCode.NotAbleToSendMetadata:
+                    throw new SoundCardException("Not able to start comunication and send sound metadata.");
+
+                case SoundCardErrorCode.NotAbleToReadMetadataCommandReply:
+                    throw new SoundCardException("Sound metadata reply not received.");
+
+                case SoundCardErrorCode.MetadataCommandReplyNotCorrect:
+                    throw new SoundCardException("Metadata command reply received is not correct.");
+
+                case SoundCardErrorCode.NotAbleToSendData:
+                    throw new SoundCardException("Not able to start comunication and send sound data.");
+
+                case SoundCardErrorCode.NotAbleToReadDataCommandReply:
+                    throw new SoundCardException("Sound data reply not received.");
+
+                case SoundCardErrorCode.DataCommandReplyNotCorrect:
+                    throw new SoundCardException("Data command reply received is not correct.");
+
+                case SoundCardErrorCode.BadSoundIndex:
+                    throw new SoundCardException("Sound index not correct. Must be beween 0 and 32.");
+
+                case SoundCardErrorCode.BadSoundLength:
+                    throw new SoundCardException("Sound length not correct.");
+
+                case SoundCardErrorCode.BadSampleRate:
+                    throw new SoundCardException("Sample rate not correct or Harp Sound Card is not compatible. Available options are 96 and 192.");
+
+                case SoundCardErrorCode.BadDataType:
+                    throw new SoundCardException("Data type not correct. Available options are 0 (for integer with 32 bits) and 1 (for float with 32 bits).");
+
+                case SoundCardErrorCode.DataTypeDoNotMatch:
+                    throw new SoundCardException("Data type don't match with selected sound index.");
+
+                case SoundCardErrorCode.BadDataIndex:
+                    throw new SoundCardException("Attempt to write outside memory boundaries.");
+
+                case SoundCardErrorCode.ProducingSound:
+                    throw new SoundCardException("The Sound Board is producing a sound and is not able to receive the new sound.");
+
+                case SoundCardErrorCode.StartedProducingSound:
+                    throw new SoundCardException("The Sound Board started producing a sound which makes it not able to receive the new sound.");
+
+                case SoundCardErrorCode.NotAbleToOpenFile:
+                    throw new SoundCardException("File doesn't exist or is empty.");
+            }
+        }
+    }
+}

--- a/Interface/Harp.SoundCard/SoundCardException.cs
+++ b/Interface/Harp.SoundCard/SoundCardException.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Harp.SoundCard
+{
+    /// <summary>
+    /// Represents errors that occur while interacting with the SoundCard loader module.
+    /// </summary>
+    [Serializable]
+    public class SoundCardException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SoundCardException"/> class.
+        /// </summary>
+        public SoundCardException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SoundCardException"/> class with
+        /// a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public SoundCardException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SoundCardException"/> class with
+        /// a specified error message and a reference to the inner exception that is the
+        /// cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">
+        /// The exception that is the cause of the current exception, or a null reference
+        /// (Nothing in Visual Basic) if no inner exception is specified.
+        /// </param>
+        public SoundCardException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected SoundCardException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/Interface/Harp.SoundCard/SoundMetadata.cs
+++ b/Interface/Harp.SoundCard/SoundMetadata.cs
@@ -1,0 +1,53 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Harp.SoundCard
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct SoundMetadata
+    {
+        public int SoundIndex;
+        public int SoundLength;
+        public SampleRate SampleRate;
+        public SampleType SampleType;
+
+        internal readonly SoundCardErrorCode Validate()
+        {
+            if (SoundIndex < 2 || SoundIndex > 32)
+            {
+                return SoundCardErrorCode.BadSoundIndex;
+            }
+
+            if (SoundLength < 16)
+            {
+                return SoundCardErrorCode.BadSoundLength;
+            }
+
+            if (SampleRate != SampleRate.SampleRate96000Hz && SampleRate != SampleRate.SampleRate192000Hz)
+            {
+                return SoundCardErrorCode.BadSampleRate;
+            }
+
+            if (SampleType != SampleType.Int32 && SampleType != SampleType.Float32)
+            {
+                return SoundCardErrorCode.BadDataType;
+            }
+
+            if (SoundIndex == 0 && SampleType != SampleType.Float32)
+            {
+                return SoundCardErrorCode.DataTypeDoNotMatch;
+            }
+
+            if (SoundIndex == 1 && SampleType != SampleType.Float32)
+            {
+                return SoundCardErrorCode.DataTypeDoNotMatch;
+            }
+
+            if (SoundIndex > 1 && SampleType != SampleType.Int32)
+            {
+                return SoundCardErrorCode.DataTypeDoNotMatch;
+            }
+
+            return SoundCardErrorCode.Ok;
+        }
+    }
+}

--- a/Interface/Harp.SoundCard/UpdateSoundWaveform.cs
+++ b/Interface/Harp.SoundCard/UpdateSoundWaveform.cs
@@ -43,13 +43,6 @@ namespace Harp.SoundCard
         public SampleRate SampleRate { get; set; }
 
         /// <summary>
-        /// Gets or sets a value specifying the bit depth of each sample in the
-        /// sound waveform.
-        /// </summary>
-        [Description("Specifies the bit depth of each sample in the sound waveform.")]
-        public SampleType SampleType { get; set; }
-
-        /// <summary>
         /// Replaces the specified sound waveform in the SoundCard device with each
         /// of the sample buffers in an observable sequence.
         /// </summary>
@@ -66,7 +59,7 @@ namespace Harp.SoundCard
         {
             return source.Do(value =>
             {
-                UpdateWaveform(DeviceIndex, SoundIndex, SampleRate, SampleType, value, SoundName);
+                UpdateWaveform(DeviceIndex, SoundIndex, SampleRate, SampleType.Int32, value, SoundName);
             });
         }
 
@@ -92,15 +85,14 @@ namespace Harp.SoundCard
                     throw new InvalidOperationException("Sound waveforms must have a single channel.");
                 }
 
-                var sampleType = SampleType;
-                var depth = sampleType == SampleType.Int32 ? Depth.S32 : Depth.F32;
+                var depth = Depth.S32;
                 var soundWaveform = new byte[value.ElementSize * value.Cols * value.Rows];
                 using (var waveformHeader = Mat.CreateMatHeader(soundWaveform, value.Rows, value.Cols, depth, channels: 1))
                 {
                     CV.Convert(value, waveformHeader);
                 }
 
-                UpdateWaveform(DeviceIndex, SoundIndex, SampleRate, sampleType, soundWaveform, SoundName);
+                UpdateWaveform(DeviceIndex, SoundIndex, SampleRate, SampleType.Int32, soundWaveform, SoundName);
             });
         }
 

--- a/Interface/Harp.SoundCard/UpdateSoundWaveform.cs
+++ b/Interface/Harp.SoundCard/UpdateSoundWaveform.cs
@@ -85,9 +85,8 @@ namespace Harp.SoundCard
                     throw new InvalidOperationException("Sound waveforms must have a single channel.");
                 }
 
-                var depth = Depth.S32;
-                var soundWaveform = new byte[value.ElementSize * value.Cols * value.Rows];
-                using (var waveformHeader = Mat.CreateMatHeader(soundWaveform, value.Rows, value.Cols, depth, channels: 1))
+                var soundWaveform = new byte[sizeof(int) * value.Cols * value.Rows];
+                using (var waveformHeader = Mat.CreateMatHeader(soundWaveform, value.Rows, value.Cols, Depth.S32, channels: 1))
                 {
                     CV.Convert(value, waveformHeader);
                 }

--- a/Interface/Harp.SoundCard/UpdateSoundWaveform.cs
+++ b/Interface/Harp.SoundCard/UpdateSoundWaveform.cs
@@ -14,6 +14,13 @@ namespace Harp.SoundCard
     public class UpdateSoundWaveform : Sink<Mat>
     {
         /// <summary>
+        /// Gets or sets the index of the SoundCard device to update. If no index
+        /// is specified, the first SoundCard will be used.
+        /// </summary>
+        [Description("The index of the SoundCard device to update. If no index is specified, the first SoundCard will be used.")]
+        public int? DeviceIndex { get; set; }
+
+        /// <summary>
         /// Gets or sets the index of the sound to update.
         /// </summary>
         [Range(2, 31)]
@@ -65,7 +72,7 @@ namespace Harp.SoundCard
                     CV.Convert(value, waveformHeader);
                 }
 
-                var errorCode = WaveformHelper.WriteSoundWaveform(SoundIndex, SampleRate, sampleType, soundWaveform);
+                var errorCode = WaveformHelper.WriteSoundWaveform(DeviceIndex, SoundIndex, SampleRate, sampleType, soundWaveform);
                 if (errorCode != SoundCardErrorCode.Ok)
                 {
                     SoundCardErrorHelper.ThrowExceptionForErrorCode(errorCode);

--- a/Interface/Harp.SoundCard/UpdateSoundWaveform.cs
+++ b/Interface/Harp.SoundCard/UpdateSoundWaveform.cs
@@ -29,6 +29,13 @@ namespace Harp.SoundCard
         public int SoundIndex { get; set; } = 2;
 
         /// <summary>
+        /// Gets or sets the name of the sound to be stored in the device.
+        /// This field is optional.
+        /// </summary>
+        [Description("The name of the sound to be stored in the device. This field is optional.")]
+        public string SoundName { get; set; }
+
+        /// <summary>
         /// Gets or sets a value specifying the sample rate used to playback the
         /// sound waveform.
         /// </summary>
@@ -72,7 +79,7 @@ namespace Harp.SoundCard
                     CV.Convert(value, waveformHeader);
                 }
 
-                var errorCode = WaveformHelper.WriteSoundWaveform(DeviceIndex, SoundIndex, SampleRate, sampleType, soundWaveform);
+                var errorCode = WaveformHelper.WriteSoundWaveform(DeviceIndex, SoundIndex, SampleRate, sampleType, soundWaveform, SoundName);
                 if (errorCode != SoundCardErrorCode.Ok)
                 {
                     SoundCardErrorHelper.ThrowExceptionForErrorCode(errorCode);

--- a/Interface/Harp.SoundCard/UpdateSoundWaveform.cs
+++ b/Interface/Harp.SoundCard/UpdateSoundWaveform.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using Bonsai;
+using OpenCV.Net;
+
+namespace Harp.SoundCard
+{
+    /// <summary>
+    /// Represents an operator that replaces the specified sound waveform in the
+    /// SoundCard device with each of the sample buffers in the sequence.
+    /// </summary>
+    [Description("Replaces the specified sound waveform in the SoundCard device with each of the sample buffers in the sequence.")]
+    public class UpdateSoundWaveform : Sink<Mat>
+    {
+        /// <summary>
+        /// Gets or sets the index of the sound to update.
+        /// </summary>
+        [Range(2, 31)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The index of the sound to update.")]
+        public int SoundIndex { get; set; } = 2;
+
+        /// <summary>
+        /// Gets or sets a value specifying the sample rate used to playback the
+        /// sound waveform.
+        /// </summary>
+        [Description("Specifies the sample rate used to playback the sound waveform.")]
+        public SampleRate SampleRate { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying the bit depth of each sample in the
+        /// sound waveform.
+        /// </summary>
+        [Description("Specifies the bit depth of each sample in the sound waveform.")]
+        public SampleType SampleType { get; set; }
+
+        /// <summary>
+        /// Replaces the specified sound waveform in the SoundCard device with each
+        /// of the sample buffers in an observable sequence.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="Mat"/> objects representing all the raw samples of
+        /// the sound waveform. Continuous streaming is not supported.
+        /// </param>
+        /// <returns>
+        /// An observable sequence that is identical to the <paramref name="source"/> sequence
+        /// but where there is an additional side effect of replacing the sound waveform
+        /// of the specified sound with each of the sample buffers in the sequence.
+        /// </returns>
+        public override IObservable<Mat> Process(IObservable<Mat> source)
+        {
+            return source.Do(value =>
+            {
+                if (value.Cols != 1 && value.Rows != 1 || value.Channels != 1)
+                {
+                    throw new InvalidOperationException("Sound waveforms must have a single channel.");
+                }
+
+                var sampleType = SampleType;
+                var depth = sampleType == SampleType.Int32 ? Depth.S32 : Depth.F32;
+                var soundWaveform = new byte[value.ElementSize * value.Cols * value.Rows];
+                using (var waveformHeader = Mat.CreateMatHeader(soundWaveform, value.Rows, value.Cols, depth, channels: 1))
+                {
+                    CV.Convert(value, waveformHeader);
+                }
+
+                var errorCode = WaveformHelper.WriteSoundWaveform(SoundIndex, SampleRate, sampleType, soundWaveform);
+                if (errorCode != SoundCardErrorCode.Ok)
+                {
+                    SoundCardErrorHelper.ThrowExceptionForErrorCode(errorCode);
+                }
+            });
+        }
+    }
+}

--- a/Interface/Harp.SoundCard/WaveformHelper.cs
+++ b/Interface/Harp.SoundCard/WaveformHelper.cs
@@ -1,0 +1,239 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using LibUsbDotNet;
+using LibUsbDotNet.Main;
+
+namespace Harp.SoundCard
+{
+    internal class WaveformHelper
+    {
+        public static UsbDeviceFinder UsbFinder = new(0x04D8, 0xEE6A);
+
+        public static unsafe SoundCardErrorCode WriteSoundWaveform(int soundIndex, SampleRate sampleRate, SampleType sampleType, byte[] soundWaveform)
+        {
+            const int MetadataSize = 2048;
+            const int MaxBufferSize = 32768;
+            using var usbDevice = UsbDevice.OpenUsbDevice(UsbFinder);
+            try
+            {
+                // Check if usb device is open and ready
+                if (usbDevice == null)
+                {
+                    return SoundCardErrorCode.HarpSoundCardNotDetected;
+                }
+
+                // If this is a "whole" usb device (libusb-win32, linux libusb)
+                // it will have an IUsbDevice interface. If not (WinUSB) the 
+                // variable will be null indicating this is an interface of a 
+                // device.
+                if (usbDevice is IUsbDevice wholeUsbDevice)
+                {
+                    // This is a "whole" USB device. Before it can be used, 
+                    // the desired configuration and interface must be selected.
+
+                    // Select config #1
+                    wholeUsbDevice.SetConfiguration(1);
+
+                    // Claim interface #0.
+                    wholeUsbDevice.ClaimInterface(0);
+                }
+
+                using var reader = usbDevice.OpenEndpointReader(ReadEndpointID.Ep01);
+                using var writer = usbDevice.OpenEndpointWriter(WriteEndpointID.Ep01);
+
+                /*************************************
+                 * Create user metadata byte array with 2048 bytes
+                 ************************************/
+                /* [0:169]     sound_filename               */
+                /* [170:339]   metadata_filename            */
+                /* [340:511]   description_filename         */
+                /* [512:1535]  metadata_filename content    */
+                /* [1536:2047] description_filename content */
+
+                var userMetadata = new byte[MetadataSize];
+                //Buffer.BlockCopy(Encoding.ASCII.GetBytes(fileName), 0, userMetadata, 0, fileName.Length);
+
+                //if (userMetadataExists)
+                //{
+                //    Buffer.BlockCopy(Encoding.ASCII.GetBytes(userMetadataFileName), 0, userMetadata, 170, userMetadataFileName.Length);
+                //    metadataFileStream.Read(userMetadata, 512, 1024);
+                //}
+
+                //if (userDescriptionExists)
+                //{
+                //    Buffer.BlockCopy(Encoding.ASCII.GetBytes(userDescriptionFileName), 0, userMetadata, 340, userDescriptionFileName.Length);
+                //    descriptionFileStream.Read(userMetadata, 512 + 1024, 512);
+                //}
+
+                /*************************************
+                 * Build sound header
+                 ************************************/
+                SoundMetadata soundMetadata;
+                soundMetadata.SoundIndex = soundIndex;
+                soundMetadata.SoundLength = soundWaveform.Length / 4;
+                soundMetadata.SampleRate = sampleRate;
+                soundMetadata.SampleType = sampleType;
+
+                /*************************************
+                 * Create auxiliary parameters
+                 ************************************/
+                long soundFileSizeInSamples = soundMetadata.SoundLength;
+                int commandsToBeSent = (int)(
+                    soundFileSizeInSamples * 4 / MaxBufferSize +
+                    (((soundFileSizeInSamples * 4 % MaxBufferSize) != 0) ? 1 : 0));
+
+                /*************************************
+                 * Create byte arrays for commands
+                 ************************************/
+                /* Metadata command lenght: 'c' 'm' 'd' '0x80' + random + metadata  + 32768 + 2048 + 'f' */
+                /* Data command lenght:     'c' 'm' 'd' '0x81' + random + dataIndex + 32768 + 'f'        */
+                /* Reset command lenght:    'c' 'm' 'd' '0x88' + 'f'                                     */
+                var metadataCmd = new byte[4 + sizeof(int) + sizeof(SoundMetadata) + MaxBufferSize + MetadataSize + 1];
+                var dataCmd = new byte[4 + sizeof(int) + sizeof(int) + MaxBufferSize + 1];
+                var resetCmd = new byte[5];
+
+                int metadataCmdDataIndex = 4 + sizeof(int) + sizeof(SoundMetadata);
+                int dataCmdDataIndex = 4 + sizeof(int) + sizeof(int);
+
+                byte metadataCmdHeader = 0x80;
+                byte dataCmdHeader = 0x81;
+                byte resetCmdHeader = 0x88;
+
+                /*************************************
+                 * Create byte array to receive replies
+                 ************************************/
+                /* Metadata command reply: 'c' 'm' 'd' '0x80' + random + error */
+                /* Data command reply:     'c' 'm' 'd' '0x81' + random + error */
+                int commandReplyLength = 4 + sizeof(int) + sizeof(int);
+                byte[] commandReply = new byte[commandReplyLength];
+
+                /*************************************
+                 * Prepare metadata command
+                 ************************************/
+                var soundMetadataValidation = soundMetadata.Validate();
+                if (soundMetadataValidation != SoundCardErrorCode.Ok)
+                {
+                    return soundMetadataValidation;
+                }
+
+                metadataCmd[0] = Convert.ToByte('c');
+                metadataCmd[1] = Convert.ToByte('m');
+                metadataCmd[2] = Convert.ToByte('d');
+                metadataCmd[3] = metadataCmdHeader;
+                Marshal.Copy(new IntPtr(&soundMetadata), metadataCmd, 8, sizeof(SoundMetadata));
+                Buffer.BlockCopy(userMetadata, 0, metadataCmd, 8 + sizeof(SoundMetadata) + MaxBufferSize, userMetadata.Length);
+                metadataCmd[metadataCmd.Length - 1] = Convert.ToByte('f');
+
+                /*************************************
+                 * Prepare data command
+                 ************************************/
+                dataCmd[0] = Convert.ToByte('c');
+                dataCmd[1] = Convert.ToByte('m');
+                dataCmd[2] = Convert.ToByte('d');
+                dataCmd[3] = dataCmdHeader;
+                dataCmd[dataCmd.Length - 1] = Convert.ToByte('f');
+
+                /*************************************
+                 * Prepare reset command
+                 ************************************/
+                resetCmd[0] = Convert.ToByte('c');
+                resetCmd[1] = Convert.ToByte('m');
+                resetCmd[2] = Convert.ToByte('d');
+                resetCmd[3] = resetCmdHeader;
+                resetCmd[4] = Convert.ToByte('f');
+
+                /*************************************
+                 * Send metadata command and receive reply
+                 ************************************/
+                int bytesSent;
+                int bytesRead;
+                int randomReceived;
+                int errorReceived;
+                int writeTimeout = 2000;
+                int readTimeout = 2000;
+                Random randomInt = new();
+                int randomSent = randomInt.Next();
+
+                using var soundFileStream = new MemoryStream(soundWaveform);
+                Buffer.BlockCopy(BitConverter.GetBytes(randomSent), 0, metadataCmd, 4, sizeof(int));
+                soundFileStream.Read(metadataCmd, metadataCmdDataIndex, MaxBufferSize);
+                reader.Flush();
+
+                var ec = writer.Write(metadataCmd, 0, metadataCmd.Length, writeTimeout, out bytesSent);
+                if (ec != 0) return SoundCardErrorCode.NotAbleToSendMetadata;
+
+                ec = reader.Read(commandReply, readTimeout, out bytesRead);
+                if (ec != 0) return SoundCardErrorCode.NotAbleToReadMetadataCommandReply;
+
+                randomReceived = BitConverter.ToInt32(commandReply, 4);
+                errorReceived = BitConverter.ToInt32(commandReply, 8);
+                if (randomSent != randomReceived) return SoundCardErrorCode.MetadataCommandReplyNotCorrect;
+
+                for (int i = 0; i < 8; i++)
+                {
+                    if (metadataCmd[i] != commandReply[i])
+                    {
+                        return SoundCardErrorCode.MetadataCommandReplyNotCorrect;
+                    }
+                }
+
+                if ((SoundCardErrorCode)errorReceived != SoundCardErrorCode.Ok)
+                {
+                    return soundMetadata.Validate();
+                }
+
+                /*************************************
+                 * Send data commands and receive replies
+                 ************************************/
+                int dataIndex = 0;
+                int bytesFromFile;
+                while (--commandsToBeSent > 0)
+                {
+                    randomSent = randomInt.Next();
+                    Buffer.BlockCopy(BitConverter.GetBytes(randomSent), 0, dataCmd, 4, sizeof(int));
+                    Buffer.BlockCopy(BitConverter.GetBytes(++dataIndex), 0, dataCmd, 8, sizeof(int));
+                    bytesFromFile = soundFileStream.Read(dataCmd, dataCmdDataIndex, MaxBufferSize);
+
+                    ec = writer.Write(dataCmd, 0, dataCmd.Length, writeTimeout, out bytesSent);
+                    if (ec != 0) return SoundCardErrorCode.NotAbleToSendData;
+
+                    ec = reader.Read(commandReply, readTimeout, out bytesRead);
+                    if (ec != 0) return SoundCardErrorCode.NotAbleToReadDataCommandReply;
+
+                    randomReceived = BitConverter.ToInt32(commandReply, 4);
+                    errorReceived = BitConverter.ToInt32(commandReply, 8);
+                    if (randomSent != randomReceived) return SoundCardErrorCode.DataCommandReplyNotCorrect;
+
+                    for (int i = 0; i < 8; i++)
+                    {
+                        if (dataCmd[i] != commandReply[i])
+                        {
+                            return SoundCardErrorCode.DataCommandReplyNotCorrect;
+                        }
+                    }
+
+                    if ((SoundCardErrorCode)errorReceived != SoundCardErrorCode.Ok)
+                    {
+                        return soundMetadata.Validate();
+                    }
+                }
+
+                return SoundCardErrorCode.Ok;
+            }
+            finally
+            {
+                // If this is a "whole" usb device (libusb-win32, linux libusb-1.0)
+                // it exposes an IUsbDevice interface. If not (WinUSB) the 
+                // 'wholeUsbDevice' variable will be null indicating this is 
+                // an interface of a device; it does not require or support 
+                // configuration and interface selection.
+                if (usbDevice is IUsbDevice wholeUsbDevice)
+                {
+                    // Release interface #0.
+                    wholeUsbDevice.ReleaseInterface(0);
+                }
+            }
+        }
+    }
+}

--- a/Interface/Harp.SoundCard/WaveformHelper.cs
+++ b/Interface/Harp.SoundCard/WaveformHelper.cs
@@ -17,7 +17,7 @@ namespace Harp.SoundCard
             SampleRate sampleRate,
             SampleType sampleType,
             byte[] soundWaveform,
-            string waveformName = null)
+            string soundName = null)
         {
             const int MetadataSize = 2048;
             const int MaxBufferSize = 32768;
@@ -66,9 +66,9 @@ namespace Harp.SoundCard
                 /* [1536:2047] description_filename content */
 
                 var userMetadata = new byte[MetadataSize];
-                if (!string.IsNullOrEmpty(waveformName))
+                if (!string.IsNullOrEmpty(soundName))
                 {
-                    Buffer.BlockCopy(Encoding.ASCII.GetBytes(waveformName), 0, userMetadata, 0, waveformName.Length);
+                    Buffer.BlockCopy(Encoding.ASCII.GetBytes(soundName), 0, userMetadata, 0, soundName.Length);
                 }
 
                 /*************************************

--- a/Interface/Harp.SoundCard/WaveformHelper.cs
+++ b/Interface/Harp.SoundCard/WaveformHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 using LibUsbDotNet;
 using LibUsbDotNet.Main;
 
@@ -10,7 +11,13 @@ namespace Harp.SoundCard
     {
         public static UsbDeviceFinder UsbFinder = new(0x04D8, 0xEE6A);
 
-        public static unsafe SoundCardErrorCode WriteSoundWaveform(int? deviceIndex, int soundIndex, SampleRate sampleRate, SampleType sampleType, byte[] soundWaveform)
+        public static unsafe SoundCardErrorCode WriteSoundWaveform(
+            int? deviceIndex,
+            int soundIndex,
+            SampleRate sampleRate,
+            SampleType sampleType,
+            byte[] soundWaveform,
+            string waveformName = null)
         {
             const int MetadataSize = 2048;
             const int MaxBufferSize = 32768;
@@ -59,19 +66,10 @@ namespace Harp.SoundCard
                 /* [1536:2047] description_filename content */
 
                 var userMetadata = new byte[MetadataSize];
-                //Buffer.BlockCopy(Encoding.ASCII.GetBytes(fileName), 0, userMetadata, 0, fileName.Length);
-
-                //if (userMetadataExists)
-                //{
-                //    Buffer.BlockCopy(Encoding.ASCII.GetBytes(userMetadataFileName), 0, userMetadata, 170, userMetadataFileName.Length);
-                //    metadataFileStream.Read(userMetadata, 512, 1024);
-                //}
-
-                //if (userDescriptionExists)
-                //{
-                //    Buffer.BlockCopy(Encoding.ASCII.GetBytes(userDescriptionFileName), 0, userMetadata, 340, userDescriptionFileName.Length);
-                //    descriptionFileStream.Read(userMetadata, 512 + 1024, 512);
-                //}
+                if (!string.IsNullOrEmpty(waveformName))
+                {
+                    Buffer.BlockCopy(Encoding.ASCII.GetBytes(waveformName), 0, userMetadata, 0, waveformName.Length);
+                }
 
                 /*************************************
                  * Build sound header

--- a/Interface/Harp.SoundCard/WaveformHelper.cs
+++ b/Interface/Harp.SoundCard/WaveformHelper.cs
@@ -10,11 +10,18 @@ namespace Harp.SoundCard
     {
         public static UsbDeviceFinder UsbFinder = new(0x04D8, 0xEE6A);
 
-        public static unsafe SoundCardErrorCode WriteSoundWaveform(int soundIndex, SampleRate sampleRate, SampleType sampleType, byte[] soundWaveform)
+        public static unsafe SoundCardErrorCode WriteSoundWaveform(int? deviceIndex, int soundIndex, SampleRate sampleRate, SampleType sampleType, byte[] soundWaveform)
         {
             const int MetadataSize = 2048;
             const int MaxBufferSize = 32768;
-            using var usbDevice = UsbDevice.OpenUsbDevice(UsbFinder);
+            var usbDeviceIndex = deviceIndex.GetValueOrDefault();
+            var usbDevices = UsbDevice.AllDevices.FindAll(UsbFinder);
+            if (usbDevices.Count <= usbDeviceIndex)
+            {
+                return SoundCardErrorCode.HarpSoundCardNotDetected;
+            }
+
+            using var usbDevice = usbDevices[usbDeviceIndex].Device;
             try
             {
                 // Check if usb device is open and ready

--- a/Interface/toSoundCard/HarpSoundCard.cs
+++ b/Interface/toSoundCard/HarpSoundCard.cs
@@ -1,13 +1,10 @@
 ﻿using System;
-using System.IO;
 using System.Diagnostics;
-using System.Threading;
+using System.IO;
+using System.Reflection;
 using System.Text;
-using System.Text.RegularExpressions;
 using LibUsbDotNet;
 using LibUsbDotNet.Main;
-using System.Runtime.InteropServices;
-using System.Reflection;
 
 namespace HarpSoundCard
 {
@@ -84,7 +81,7 @@ namespace HarpSoundCard
                 #region Create folders if don't exist
                 var currentDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
                 var toDirectory = System.IO.Path.Combine(currentDirectory, "toSoundCard");
-                
+
                 if (Directory.Exists(toDirectory) == false)
                     System.IO.Directory.CreateDirectory(toDirectory);
 
@@ -130,7 +127,7 @@ namespace HarpSoundCard
                     Console.WriteLine("  -> [sample rate]  96000 or 192000");
                     Console.WriteLine("");
                     Console.WriteLine("  Note: It's recommended that \"filenames\" should have an extension.");
-                    return (int) SoundCardErrorCode.BadUserInput;
+                    return (int)SoundCardErrorCode.BadUserInput;
                 }
 
                 //string fileName = "..\\..\\1920K_samples.bin";
@@ -253,7 +250,7 @@ namespace HarpSoundCard
 
                 if (userMetadataExists)
                 {
-                    System.Buffer.BlockCopy(Encoding.ASCII.GetBytes(userMetadataFileName), 0, userMetadata, 170, userMetadataFileName.Length);                    
+                    System.Buffer.BlockCopy(Encoding.ASCII.GetBytes(userMetadataFileName), 0, userMetadata, 170, userMetadataFileName.Length);
                     metadataFileStream.Read(userMetadata, 512, 1024);
                 }
 
@@ -269,7 +266,7 @@ namespace HarpSoundCard
                  ************************************/
                 SoundMetadata soundMetadata;
                 soundMetadata.soundIndex = soundIndex;
-                soundMetadata.soundLength = (int) soundFileSizeInSamples; // samples per sound 1048576;
+                soundMetadata.soundLength = (int)soundFileSizeInSamples; // samples per sound 1048576;
                 soundMetadata.sampleRate = sampleRate;
                 soundMetadata.dataType = dataType;
 
@@ -281,15 +278,15 @@ namespace HarpSoundCard
                 /* Data command lenght:     'c' 'm' 'd' '0x81' + random + dataIndex + 32768 + 'f'        */
                 /* Reset command lenght:    'c' 'm' 'd' '0x88' + 'f'                                     */
                 var metadataCmd = new byte[4 + sizeof(int) + soundMetadata.GetSize() + 32768 + 2048 + 1];
-                var dataCmd     = new byte[4 + sizeof(int) + sizeof(int) + 32768 + 1];
-                var resetCmd    = new byte[5];
+                var dataCmd = new byte[4 + sizeof(int) + sizeof(int) + 32768 + 1];
+                var resetCmd = new byte[5];
 
                 int metadataCmdDataIndex = 4 + sizeof(int) + soundMetadata.GetSize();
-                int dataCmdDataIndex     = 4 + sizeof(int) + sizeof(int);
+                int dataCmdDataIndex = 4 + sizeof(int) + sizeof(int);
 
                 byte metadataCmdHeader = 0x80;
-                byte dataCmdHeader     = 0x81;
-                byte resetCmdHeader    = 0x88;
+                byte dataCmdHeader = 0x81;
+                byte resetCmdHeader = 0x88;
 
 
                 /*************************************
@@ -380,7 +377,7 @@ namespace HarpSoundCard
                 soundFileStream.Read(metadataCmd, metadataCmdDataIndex, 32768);
                 //Console.WriteLine("Elapsed time (get 32KB from the file): " + stopwatch.ElapsedMilliseconds + " ms");
 
-                reader.Flush();                
+                reader.Flush();
 
                 ec = writer.Write(metadataCmd, 0, metadataCmd.Length, writeTimeout, out bytesSent);
                 if (ec != ErrorCode.None) throw new Exception("NotAbleToSendMetadata");
@@ -419,9 +416,9 @@ namespace HarpSoundCard
                 for (int i = 0; i < 8; i++)
                     if (metadataCmd[i] != commandReply[i]) throw new Exception("MetadataCommandReplyNotCorrect");
 
-                if ((SoundCardErrorCode) errorReceived != SoundCardErrorCode.Ok)
+                if ((SoundCardErrorCode)errorReceived != SoundCardErrorCode.Ok)
                 {
-                    Console.WriteLine("Error: " + (SoundCardErrorCode) errorReceived);
+                    Console.WriteLine("Error: " + (SoundCardErrorCode)errorReceived);
                     return (int)soundMetadata.CheckData();
                 }
 
@@ -492,7 +489,7 @@ namespace HarpSoundCard
                 //Console.WriteLine("Ticks: " + stopwatch.ElapsedTicks);
                 Console.WriteLine("Elapsed time: " + stopwatch.ElapsedMilliseconds + " ms");
                 //Console.WriteLine("Bandwidth: " + bandwidth_MBps.ToString("0.000") + " MB/s");
-                Console.WriteLine("Bandwidth: " + bandwidth_Mbps.ToString("0.0") + " Mb/s");                
+                Console.WriteLine("Bandwidth: " + bandwidth_Mbps.ToString("0.0") + " Mb/s");
             }
             catch (Exception ex)
             {
@@ -501,7 +498,7 @@ namespace HarpSoundCard
             }
             finally
             {
-                if (MyUsbDevice != null) 
+                if (MyUsbDevice != null)
                 {
                     if (MyUsbDevice.IsOpen)
                     {

--- a/Interface/toSoundCard/ReturnErrorCode.cs
+++ b/Interface/toSoundCard/ReturnErrorCode.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
 
 namespace HarpSoundCard
 {

--- a/Interface/toSoundCard/SoundMetadata.cs
+++ b/Interface/toSoundCard/SoundMetadata.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace HarpSoundCard
 {
@@ -42,14 +40,14 @@ namespace HarpSoundCard
 
             return arr;
         }
-        
+
         public void ToStructure(byte[] bytearray)
         {
             int sizeOfStruture = Marshal.SizeOf(this);
 
             IntPtr ptr = Marshal.AllocHGlobal(sizeOfStruture);
 
-            Marshal.Copy(bytearray, 0, ptr, sizeOfStruture);            
+            Marshal.Copy(bytearray, 0, ptr, sizeOfStruture);
             this = (SoundMetadata)Marshal.PtrToStructure(ptr, typeof(SoundMetadata));
 
             Marshal.FreeHGlobal(ptr);
@@ -107,6 +105,4 @@ namespace HarpSoundCard
 
         }
     }
-
-    
 }


### PR DESCRIPTION
Currently sound waveforms need to be uploaded to the device manually using either the CLI or custom GUI interface. This prevents dynamic updating of sounds at runtime, and also makes it harder to automate reproducible experimental conditions.

This PR introduces a new operator `UpdateSoundWaveform` which interfaces directly with the SoundCard memory device via libusb and allows dynamic uploading of waveform data in individual sound banks. Key features of this new operator:
- A `SoundIndex` property allows specifying which memory bank to update;
- Both `byte[]` and `Mat` types are supported for waveform data;
- Both sample rates of 96 kHz and 192 kHz are supported;
- A `SampleType` property is exposed, but only `Int32` sample types are currently supported;
- Waveform data can be updated even while other sounds are playing, as long as the sampling rate of 96 kHz is used;
- An optional `DeviceIndex` property allows specifying which device to update in the case where multiple devices are connected;
- An optional `SoundName` can be specified in the operator and will be included in the metadata stored in the memory bank;
- The behavior of the operator is blocking by default, so propagation of the original waveform data notification happens only after the data has been entirely transmitted to the device.

Fixes #3 