### PR TITLE
Update interface and package metadata

### DIFF
--- a/Generators/Generators.csproj
+++ b/Generators/Generators.csproj
@@ -15,7 +15,7 @@
     <FirmwarePath>..\Firmware\Harp.SoundCard</FirmwarePath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Harp.Generators" Version="0.3.0" GeneratePathProperty="true" />
+    <PackageReference Include="Harp.Generators" Version="0.4.0" GeneratePathProperty="true" />
   </ItemGroup>
   <Target Name="TextTransform" BeforeTargets="AfterBuild">
     <PropertyGroup>

--- a/Interface/Harp.SoundCard/AsyncDevice.Generated.cs
+++ b/Interface/Harp.SoundCard/AsyncDevice.Generated.cs
@@ -14,15 +14,18 @@ namespace Harp.SoundCard
         /// <param name="portName">
         /// The name of the serial port used to communicate with the Harp device.
         /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the operation.
+        /// </param>
         /// <returns>
         /// A task that represents the asynchronous initialization operation. The value of
         /// the <see cref="Task{TResult}.Result"/> parameter contains a new instance of
         /// the <see cref="AsyncDevice"/> class.
         /// </returns>
-        public static async Task<AsyncDevice> CreateAsync(string portName)
+        public static async Task<AsyncDevice> CreateAsync(string portName, CancellationToken cancellationToken = default)
         {
             var device = new AsyncDevice(portName);
-            var whoAmI = await device.ReadWhoAmIAsync();
+            var whoAmI = await device.ReadWhoAmIAsync(cancellationToken);
             if (whoAmI != Device.WhoAmI)
             {
                 var errorMessage = string.Format(

--- a/Interface/Harp.SoundCard/Harp.SoundCard.csproj
+++ b/Interface/Harp.SoundCard/Harp.SoundCard.csproj
@@ -3,19 +3,18 @@
   <PropertyGroup>
     <Title>Harp - SoundCard</Title>
     <Authors>harp-tech</Authors>
-    <Copyright>Copyright © harp-tech and Contributors 2023</Copyright>
+    <Copyright>Copyright © harp-tech and Contributors</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
     <Description>Bonsai Library containing interfaces for data acquisition and control of Harp SoundCard devices.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageType>Dependency;BonsaiLibrary</PackageType>
     <PackageTags>Harp SoundCard Bonsai Rx</PackageTags>
     <PackageProjectUrl>https://harp-tech.org</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/harp-tech/device.soundcard.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageOutputPath>..\bin\$(Configuration)</PackageOutputPath>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -25,14 +24,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Harp" Version="3.5.0" />
+    <PackageReference Include="Bonsai.Harp" Version="3.6.0" />
     <PackageReference Include="LibUsbDotNet" Version="2.2.29" />
     <PackageReference Include="OpenCV.Net" Version="3.4.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\LICENSE" PackagePath="/" />
-    <Content Include="..\icon.png" PackagePath="/" />
+    <None Include="$(ProjectDir)$(PackageReadmeFile)" Pack="true" PackagePath="/" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\$(PackageLicenseFile)" Pack="true" PackagePath="/" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\$(PackageIcon)" Pack="true" PackagePath="/" Visible="false" />
     <EmbeddedResource Include="..\..\device.yml" />
   </ItemGroup>
 

--- a/Interface/Harp.SoundCard/README.md
+++ b/Interface/Harp.SoundCard/README.md
@@ -1,0 +1,26 @@
+## About
+
+`Harp.SoundCard` provides an asynchronous API and reactive operators for data acquisition and control of [Harp SoundCard](https://harp-tech.org/api/Harp.SoundCard.html) devices.
+
+## How to Use
+
+To use `Harp.SoundCard` for visual reactive programming, please install this package using the [Bonsai package manager](https://bonsai-rx.org/docs/articles/packages.html).
+
+The package can also be used from any .NET application:
+```c#
+using Harp.SoundCard;
+
+using var device = await Device.CreateAsync("COM3");
+var whoAmI = await device.ReadWhoAmIAsync();
+var deviceName = await device.ReadDeviceNameAsync();
+var timestamp = await device.ReadTimestampSecondsAsync();
+Console.WriteLine($"{deviceName} WhoAmI: {whoAmI} Timestamp (s): {timestamp}");
+```
+
+## Additional Documentation
+
+For additional documentation and examples, refer to the [official Harp documentation](https://harp-tech.org/api/Harp.SoundCard.html).
+
+## Feedback & Contributing
+
+`Harp.SoundCard` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/harp-tech/device.soundcard).

--- a/Interface/LICENSE
+++ b/Interface/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2023 harp-tech and Contributors
+Copyright (C) harp-tech and Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/Interface/fromSoundCard/HarpSoundCard.cs
+++ b/Interface/fromSoundCard/HarpSoundCard.cs
@@ -267,9 +267,8 @@ namespace HarpSoundCard
 
         public static int Main(string[] args)
         {
+            
             ErrorCode ec = ErrorCode.None;
-
-            bool debug = false;
             bool ignoreInputs = false;
 
             try

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
The new version of the `Harp.Generators` package includes the new `DeviceDataWriter` operator to make it easier to save all data using the standardized Harp logging format.

To improve package discoverability and understanding we embed a README file directly in the device package. We also simplify a few properties in the project file and remove date range from the interface copyright statement.