### PR TITLE
Update LibUsbDotNet to latest version

### DIFF
--- a/Interface/Harp.SoundCard/Harp.SoundCard.csproj
+++ b/Interface/Harp.SoundCard/Harp.SoundCard.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bonsai.Harp" Version="3.6.0" />
-    <PackageReference Include="LibUsbDotNet" Version="2.2.29" />
+    <PackageReference Include="LibUsbDotNet" Version="3.0.167-alpha" />
     <PackageReference Include="OpenCV.Net" Version="3.4.2" />
   </ItemGroup>
 

--- a/Interface/Harp.SoundCard/Harp.SoundCard.csproj
+++ b/Interface/Harp.SoundCard/Harp.SoundCard.csproj
@@ -16,7 +16,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageOutputPath>..\bin\$(Configuration)</PackageOutputPath>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <VersionPrefix>0.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>

--- a/Interface/Harp.SoundCard/WaveformHelper.cs
+++ b/Interface/Harp.SoundCard/WaveformHelper.cs
@@ -2,15 +2,13 @@
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
-using LibUsbDotNet;
 using LibUsbDotNet.Main;
+using LibUsbDotNet.LibUsb;
 
 namespace Harp.SoundCard
 {
     internal class WaveformHelper
     {
-        public static UsbDeviceFinder UsbFinder = new(0x04D8, 0xEE6A);
-
         public static unsafe SoundCardErrorCode WriteSoundWaveform(
             int? deviceIndex,
             int soundIndex,
@@ -21,40 +19,54 @@ namespace Harp.SoundCard
         {
             const int MetadataSize = 2048;
             const int MaxBufferSize = 32768;
+
+            var usbFinder = new UsbDeviceFinder{
+                Vid = 0x04D8,
+                Pid = 0xEE6A
+            };
+
             var usbDeviceIndex = deviceIndex.GetValueOrDefault();
-            var usbDevices = UsbDevice.AllDevices.FindAll(UsbFinder);
-            if (usbDevices.Count <= usbDeviceIndex)
+            if (usbDeviceIndex < 0)
             {
                 return SoundCardErrorCode.HarpSoundCardNotDetected;
             }
 
-            using var usbDevice = usbDevices[usbDeviceIndex].Device;
+            using var context = new UsbContext();
+            using var devices = context.FindAll(usbFinder);
+
+            if (devices.Count <= usbDeviceIndex)
+            {
+                return SoundCardErrorCode.HarpSoundCardNotDetected;
+            }
+
+            var usbDevice = devices[usbDeviceIndex];
+
             try
             {
-                // Check if usb device is open and ready
-                if (usbDevice == null)
-                {
-                    return SoundCardErrorCode.HarpSoundCardNotDetected;
-                }
+                usbDevice.Open();
 
                 // If this is a "whole" usb device (libusb-win32, linux libusb)
                 // it will have an IUsbDevice interface. If not (WinUSB) the 
                 // variable will be null indicating this is an interface of a 
                 // device.
-                if (usbDevice is IUsbDevice wholeUsbDevice)
+                IUsbDevice wholeUsbDevice = usbDevice;
+                if (!ReferenceEquals(wholeUsbDevice, null))
                 {
                     // This is a "whole" USB device. Before it can be used, 
                     // the desired configuration and interface must be selected.
 
-                    // Select config #1
-                    wholeUsbDevice.SetConfiguration(1);
+                    // Select config #1 only if not active
+                    if (wholeUsbDevice.Configs[0].ConfigurationValue != wholeUsbDevice.Configuration)
+                    {
+                        wholeUsbDevice.SetConfiguration(1);
+                    }
 
                     // Claim interface #0.
                     wholeUsbDevice.ClaimInterface(0);
                 }
 
-                using var reader = usbDevice.OpenEndpointReader(ReadEndpointID.Ep01);
-                using var writer = usbDevice.OpenEndpointWriter(WriteEndpointID.Ep01);
+                var reader = usbDevice.OpenEndpointReader(ReadEndpointID.Ep01);
+                var writer = usbDevice.OpenEndpointWriter(WriteEndpointID.Ep01);
 
                 /*************************************
                  * Create user metadata byte array with 2048 bytes
@@ -163,7 +175,7 @@ namespace Harp.SoundCard
                 using var soundFileStream = new MemoryStream(soundWaveform);
                 Buffer.BlockCopy(BitConverter.GetBytes(randomSent), 0, metadataCmd, 4, sizeof(int));
                 soundFileStream.Read(metadataCmd, metadataCmdDataIndex, MaxBufferSize);
-                reader.Flush();
+                reader.ReadFlush();
 
                 var ec = writer.Write(metadataCmd, 0, metadataCmd.Length, writeTimeout, out bytesSent);
                 if (ec != 0) return SoundCardErrorCode.NotAbleToSendMetadata;
@@ -228,15 +240,21 @@ namespace Harp.SoundCard
             }
             finally
             {
-                // If this is a "whole" usb device (libusb-win32, linux libusb-1.0)
-                // it exposes an IUsbDevice interface. If not (WinUSB) the 
-                // 'wholeUsbDevice' variable will be null indicating this is 
-                // an interface of a device; it does not require or support 
-                // configuration and interface selection.
-                if (usbDevice is IUsbDevice wholeUsbDevice)
+                if (usbDevice != null && usbDevice.IsOpen)
                 {
-                    // Release interface #0.
-                    wholeUsbDevice.ReleaseInterface(0);
+                    // If this is a "whole" usb device (libusb-win32, linux libusb-1.0)
+                    // it exposes an IUsbDevice interface. If not (WinUSB) the 
+                    // 'wholeUsbDevice' variable will be null indicating this is 
+                    // an interface of a device; it does not require or support 
+                    // configuration and interface selection.
+                    IUsbDevice wholeUsbDevice = usbDevice;
+                    if (!ReferenceEquals(wholeUsbDevice, null))
+                    {
+                        // Release interface #0.
+                        wholeUsbDevice.ReleaseInterface(0);
+                    }
+
+                    usbDevice.Close();
                 }
             }
         }

--- a/Interface/Harp.SoundCard/WaveformHelper.cs
+++ b/Interface/Harp.SoundCard/WaveformHelper.cs
@@ -105,17 +105,14 @@ namespace Harp.SoundCard
                  ************************************/
                 /* Metadata command lenght: 'c' 'm' 'd' '0x80' + random + metadata  + 32768 + 2048 + 'f' */
                 /* Data command lenght:     'c' 'm' 'd' '0x81' + random + dataIndex + 32768 + 'f'        */
-                /* Reset command lenght:    'c' 'm' 'd' '0x88' + 'f'                                     */
                 var metadataCmd = new byte[4 + sizeof(int) + sizeof(SoundMetadata) + MaxBufferSize + MetadataSize + 1];
                 var dataCmd = new byte[4 + sizeof(int) + sizeof(int) + MaxBufferSize + 1];
-                var resetCmd = new byte[5];
 
                 int metadataCmdDataIndex = 4 + sizeof(int) + sizeof(SoundMetadata);
                 int dataCmdDataIndex = 4 + sizeof(int) + sizeof(int);
 
                 byte metadataCmdHeader = 0x80;
                 byte dataCmdHeader = 0x81;
-                byte resetCmdHeader = 0x88;
 
                 /*************************************
                  * Create byte array to receive replies
@@ -150,15 +147,6 @@ namespace Harp.SoundCard
                 dataCmd[2] = Convert.ToByte('d');
                 dataCmd[3] = dataCmdHeader;
                 dataCmd[dataCmd.Length - 1] = Convert.ToByte('f');
-
-                /*************************************
-                 * Prepare reset command
-                 ************************************/
-                resetCmd[0] = Convert.ToByte('c');
-                resetCmd[1] = Convert.ToByte('m');
-                resetCmd[2] = Convert.ToByte('d');
-                resetCmd[3] = resetCmdHeader;
-                resetCmd[4] = Convert.ToByte('f');
 
                 /*************************************
                  * Send metadata command and receive reply


### PR DESCRIPTION
Hi, this PR updates LibUsbDotNet to the latest available version (3.0.167-alpha). 

Although this is an alpha version, there seems to be a consensus that it is in a state that will be released a final version soon (please see https://github.com/LibUsbDotNet/LibUsbDotNet/issues/266). 

The main advantage of this PR is that this version bundles the native libusb DLLs for the different platforms and architectures. This is important for bundled .app macOS applications that use libusb, since they aren't able to find correctly the native DLL due to restrictions with SIP.

Some necessary changes were needed to the project, mainly the addition of net8.0 as a TargetFramework and some API changes on how to handle the connection.

This PR also fixes an issue on Linux, where this was setting the Configuration for the device, even if that Configuration was already set. According to libusb's documentation (here: https://libusb.sourceforge.io/api-1.0/group__libusb__dev.html#ga785ddea63a2b9bcb879a614ca4867bed), on this occasion, the call to the method acts as a reset, which was preventing subsequent usage of UpdateWaveform.